### PR TITLE
Support optional Zod input (Close #4)

### DIFF
--- a/src/__snapshots__/generate.test.ts.snap
+++ b/src/__snapshots__/generate.test.ts.snap
@@ -400,3 +400,118 @@ Object {
   },
 }
 `;
+
+exports[`works with optional zod object 1`] = `
+Object {
+  "info": Object {
+    "title": "tRPC HTTP-RPC",
+    "version": "",
+  },
+  "openapi": "3.0.0",
+  "paths": Object {
+    "/trpc/dummy.hello.world": Object {
+      "get": Object {
+        "description": "ok",
+        "operationId": "dummy.hello.world",
+        "parameters": Array [
+          Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "additionalProperties": false,
+                  "properties": Object {
+                    "name": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "name",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "in": "query",
+            "name": "input",
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "additionalProperties": false,
+                  "properties": Object {
+                    "result": Object {
+                      "additionalProperties": false,
+                      "properties": Object {
+                        "data": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "data",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": Array [
+                    "result",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "",
+          },
+        },
+        "tags": Array [
+          "dummy",
+        ],
+      },
+    },
+    "/trpc/example.optionalObjectTest": Object {
+      "get": Object {
+        "operationId": "example.optionalObjectTest",
+        "parameters": Array [
+          Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "anyOf": Array [
+                    Object {
+                      "not": Object {},
+                    },
+                    Object {
+                      "additionalProperties": false,
+                      "properties": Object {
+                        "anOption": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "anOption",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+            "in": "query",
+            "name": "input",
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "description": "",
+          },
+        },
+        "tags": Array [
+          "example",
+        ],
+      },
+    },
+  },
+}
+`;

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -79,3 +79,25 @@ it('lets you post-process each operation, giving typed access to the meta', () =
   )
   expect(doc).toMatchSnapshot()
 })
+
+it('works with optional zod object', () => {
+  const t = initTRPC.meta<OperationMeta>().create()
+  const router = t.router({
+    example: t.router({
+      optionalObjectTest: t.procedure
+        .input(
+          z.object({
+            anOption: z.string(),
+          }).optional()
+        )
+        .query(() => null),
+    }),
+    dummy: createDummyRouter(t),
+  })
+  const doc = generateOpenAPIDocumentFromTRPCRouter(router, {
+    pathPrefix: '/trpc',
+  })
+  fs.mkdirSync('temp/examples', { recursive: true })
+  fs.writeFileSync('temp/examples/optional-object.json', JSON.stringify(doc, null, 2))
+  expect(doc).toMatchSnapshot()
+})

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -86,9 +86,11 @@ it('works with optional zod object', () => {
     example: t.router({
       optionalObjectTest: t.procedure
         .input(
-          z.object({
-            anOption: z.string(),
-          }).optional()
+          z
+            .object({
+              anOption: z.string(),
+            })
+            .optional(),
         )
         .query(() => null),
     }),
@@ -98,6 +100,9 @@ it('works with optional zod object', () => {
     pathPrefix: '/trpc',
   })
   fs.mkdirSync('temp/examples', { recursive: true })
-  fs.writeFileSync('temp/examples/optional-object.json', JSON.stringify(doc, null, 2))
+  fs.writeFileSync(
+    'temp/examples/optional-object.json',
+    JSON.stringify(doc, null, 2),
+  )
   expect(doc).toMatchSnapshot()
 })

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -144,9 +144,9 @@ function asZodObject(input: unknown) {
     getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodVoid &&
     getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodOptional
   ) {
-    throw new Error("Expected a ZodObject, received: " + String(input));
+    throw new Error("Expected a ZodObject, received: " + String(input))
   }
-  return input as AnyZodObject;
+  return input as AnyZodObject
 }
 
 function asZodType(input: unknown) {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -144,7 +144,7 @@ function asZodObject(input: unknown) {
     getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodVoid &&
     getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodOptional
   ) {
-    throw new Error("Expected a ZodObject, received: " + String(input))
+    throw new Error('Expected a ZodObject, received: ' + String(input))
   }
   return input as AnyZodObject
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -139,10 +139,14 @@ function getZodTypeName(input: unknown) {
 }
 
 function asZodObject(input: unknown) {
-  if (getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodObject) {
-    throw new Error('Expected a ZodObject, received: ' + String(input))
+  if (
+    getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodObject &&
+    getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodVoid &&
+    getZodTypeName(input) !== ZodFirstPartyTypeKind.ZodOptional
+  ) {
+    throw new Error("Expected a ZodObject, received: " + String(input));
   }
-  return input as AnyZodObject
+  return input as AnyZodObject;
 }
 
 function asZodType(input: unknown) {


### PR DESCRIPTION
Hello, thank you for a useful library 👍 

I've noticed an issue in one of my projects. Currently, the following code fails with an exception if an optional type is used:

```js
{
  path: procedure.meta({}).input(
    z
      .object({
        anOption: z.string(),
      })
      .optional(),
  );
}

```

This occurs because `.optional()` returns an instance of `ZodOptional`, not `ZodObject`. Using `.optional()` needed when adding new params to an endpoint, so existing code that doesn't use these params still works. I want to avoid BC breaks for my public API.

This PR fixes the issue I encountered, which was also reported in: https://github.com/dtinth/openapi-trpc/issues/4